### PR TITLE
Add Newegg and Micro Center adapters

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Open‑Box Radar
 
-Open‑Box Radar is a Next.js 14 app + Cloudflare Worker that collects open‑box deals, stores normalized snapshots in Postgres, and exposes fast search and browse. Best Buy uses the official Open Box API; Micro Center can be scraped via DOM. The UI is open to browse/search (no login). “Watch” and “Save search” use passwordless email (magic link).
+Open‑Box Radar is a Next.js 14 app + Cloudflare Worker that collects open‑box deals, stores normalized snapshots in Postgres, and exposes fast search and browse. Best Buy uses the official Open Box API; Micro Center and Newegg inventories are scraped via HTML/DOM parsers. The UI is open to browse/search (no login). “Watch” and “Save search” use passwordless email (magic link).
 
 ## Architecture overview
 - The Next.js app router experience covers the marketing site, search, and authenticated watch dashboard. Shared layout code loads the magic-link session from cookies so server and client components render consistently.
@@ -93,6 +93,8 @@ Worker (`worker/wrangler.toml` / secrets)
 - `BESTBUY_API_KEY` — Worker secret
 - Source selection: `BESTBUY_SKUS` or `BESTBUY_CATEGORY` (with `BESTBUY_PAGE_SIZE`)
 - `USE_REAL_MICROCENTER` — optional, `1` to scrape DOM
+- `MICROCENTER_STORE_IDS` — comma list of store ids (e.g. `mc-cambridge,mc-brooklyn`)
+- `USE_REAL_NEWEGG` — `1` to scrape Newegg open-box listings
 - `ENABLE_BB_ENRICHMENT`, `BB_ENRICHMENT_TTL_MIN`, `BB_ENRICHMENT_FAIL_TTL_MIN`, `BB_MAX_ENRICH_RPS`
 
 ## Data model (Drizzle)
@@ -135,8 +137,9 @@ Worker sender
 ## Retailer adapters
 
 Micro Center
-- Real DOM scrape: `worker/src/adapters/microcenter_dom.ts` via `linkedom`
+- Real DOM scrape per store: `worker/src/adapters/microcenter_dom.ts` via `linkedom`
 - Toggle with `USE_REAL_MICROCENTER=1` (else stub: `adapters/stubs.ts`)
+- Configure stores via `MICROCENTER_STORE_IDS` (defaults to `mc-cambridge`)
 
 Best Buy (official API)
 - Worker adapter: `worker/src/adapters/bestbuy_api.ts`
@@ -317,3 +320,6 @@ This section describes the current user-facing logic.
 - Read the “Business logic & product behavior” section above to understand current UX, alerting expectations, and pricing features.
 - Explore the retailer adapters in `worker/src/adapters` alongside the scheduler to see how feeds flow into `/api/ingest`.
 - Run the local seed script (`node scripts/seed_dev_items.js`) and experiment with the dashboard to trace a watch from creation through worker ingest and alert matching.
+- Newegg
+- DOM scrape of Open-Box listings: `worker/src/adapters/newegg_clearance.ts`
+- Toggle with `USE_REAL_NEWEGG=1`

--- a/db/seed/stores.newegg.json
+++ b/db/seed/stores.newegg.json
@@ -1,0 +1,10 @@
+[
+  {
+    "retailer": "newegg",
+    "store_id": "newegg-online",
+    "name": "Newegg Online",
+    "zipcode": null,
+    "city": null,
+    "state": null
+  }
+]

--- a/scripts/seed_dev_items.js
+++ b/scripts/seed_dev_items.js
@@ -26,6 +26,16 @@ async function main() {
       url: 'https://www.bestbuy.com/site/sku/DEV-BBY-001.p',
       seenAt: new Date().toISOString(),
     },
+    {
+      retailer: 'newegg',
+      storeId: 'newegg-online',
+      sku: 'DEV-NE-001',
+      title: 'DEV Newegg Open-Box GPU',
+      conditionLabel: 'Open-Box',
+      priceCents: 42999,
+      url: 'https://www.newegg.com/p/DEV-NE-001',
+      seenAt: new Date().toISOString(),
+    },
   ];
 
   const r = await fetch(INGEST, {

--- a/web/app/api/ingest/route.ts
+++ b/web/app/api/ingest/route.ts
@@ -5,7 +5,7 @@ import { and, eq, gt } from 'drizzle-orm';
 import { z } from 'zod';
 
 const Item = z.object({
-  retailer: z.enum(['bestbuy','microcenter']),
+  retailer: z.enum(['bestbuy','microcenter','newegg']),
   storeId: z.string().min(1),
   sku: z.string().optional(),
   title: z.string().min(1),
@@ -45,7 +45,7 @@ export async function POST(req: NextRequest) {
   const isDevLike = (it: z.infer<typeof Item>) => {
     const titleLooksDev = /^\s*DEV\b/i.test(it.title);
     const urlLooksDev = /example\.com/i.test(it.url);
-    const devStores = new Set(['bby-123', 'mc-cambridge']);
+    const devStores = new Set(['bby-123', 'mc-cambridge', 'newegg-online']);
     const storeLooksDev = devStores.has(it.storeId);
     return titleLooksDev || urlLooksDev || storeLooksDev;
   };

--- a/web/app/api/watches/route.ts
+++ b/web/app/api/watches/route.ts
@@ -8,7 +8,7 @@ import { Resend } from "resend";
 import { generateToken, normalizeEmail, tokenExpiry, isValidEmail } from "@/lib/auth/tokens";
 
 const WatchInput = z.object({
-  retailer: z.enum(["bestbuy","microcenter"]),
+  retailer: z.enum(["bestbuy","microcenter","newegg"]),
   sku: z.string().optional(),
   product_url: z.string().url().optional(),
   keywords: z.array(z.string()).optional(),

--- a/web/app/app/page.tsx
+++ b/web/app/app/page.tsx
@@ -31,6 +31,7 @@ async function Watches() {
         <select name="retailer" className="border rounded px-2 py-2">
           <option value="bestbuy">Best Buy</option>
           <option value="microcenter">Micro Center</option>
+          <option value="newegg">Newegg</option>
         </select>
         <input name="sku" placeholder="SKU (optional)" className="border rounded px-2 py-2" />
         <input name="zipcode" placeholder="ZIP code" required className="border rounded px-2 py-2" />

--- a/web/app/app/watches/new/page.tsx
+++ b/web/app/app/watches/new/page.tsx
@@ -2,7 +2,7 @@
 import { useEffect, useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
 
-type Retailer = "bestbuy" | "microcenter";
+type Retailer = "bestbuy" | "microcenter" | "newegg";
 type StateItem = { state: string; count: number };
 type StoreItem = { store_id: string; name: string | null; city: string | null; zipcode: string | null };
 
@@ -31,13 +31,21 @@ export default function NewWatchWizard() {
   const [priceCeiling, setPriceCeiling] = useState<string>("");
 
   useEffect(() => {
+    if (retailer === 'newegg') {
+      setUseStores(false);
+      setStates([]);
+      setStateSel('');
+      setStoreOptions([]);
+      setStoresSel([]);
+      return;
+    }
     if (useStores) {
       fetch(`/api/stores?retailer=${retailer}`).then(r => r.json()).then((d) => setStates(d.states || []));
     }
   }, [useStores, retailer]);
 
   useEffect(() => {
-    if (useStores && stateSel) {
+    if (useStores && retailer !== 'newegg' && stateSel) {
       fetch(`/api/stores?retailer=${retailer}&state=${encodeURIComponent(stateSel)}`)
         .then(r => r.json()).then((d) => setStoreOptions(d.stores || []));
     } else {
@@ -76,6 +84,7 @@ export default function NewWatchWizard() {
           <select value={retailer} onChange={(e) => setRetailer(e.target.value as Retailer)} className="border rounded px-3 py-2">
             <option value="bestbuy">Best Buy</option>
             <option value="microcenter">Micro Center</option>
+            <option value="newegg">Newegg</option>
           </select>
           <div className="flex justify-end gap-2">
             <button className="px-4 py-2 border rounded" onClick={() => router.push("/app")}>Cancel</button>
@@ -88,7 +97,7 @@ export default function NewWatchWizard() {
         <section className="space-y-3">
           <h2 className="font-medium">Step 2: Location</h2>
           <label className="flex items-center gap-2 text-sm">
-            <input type="checkbox" checked={useStores} onChange={(e) => setUseStores(e.target.checked)} />
+            <input type="checkbox" checked={useStores} disabled={retailer === 'newegg'} onChange={(e) => setUseStores(e.target.checked)} />
             Pick specific stores instead of ZIP + radius
           </label>
           {!useStores ? (

--- a/web/app/stores/[retailer]/[state]/page.tsx
+++ b/web/app/stores/[retailer]/[state]/page.tsx
@@ -19,7 +19,7 @@ export default async function RetailerStateStores({ params }: { params: { retail
     .where(and(eq(stores.retailer, retailer as any), eq(stores.state, state)))
     .orderBy(stores.city, stores.name);
 
-  const label = (id: string) => id === "bestbuy" ? "Best Buy" : id === "microcenter" ? "Micro Center" : id;
+  const label = (id: string) => id === "bestbuy" ? "Best Buy" : id === "microcenter" ? "Micro Center" : id === "newegg" ? "Newegg" : id;
 
   return (
     <main className="max-w-3xl mx-auto p-8 space-y-6">

--- a/web/app/stores/[retailer]/page.tsx
+++ b/web/app/stores/[retailer]/page.tsx
@@ -18,7 +18,7 @@ export default async function RetailerStates({ params }: { params: { retailer: s
     .map((r) => ({ state: r.state as string | null, count: Number(r.count) }))
     .filter((r) => r.state && r.state.trim().length);
 
-  const label = (id: string) => id === "bestbuy" ? "Best Buy" : id === "microcenter" ? "Micro Center" : id;
+  const label = (id: string) => id === "bestbuy" ? "Best Buy" : id === "microcenter" ? "Micro Center" : id === "newegg" ? "Newegg" : id;
 
   return (
     <main className="max-w-3xl mx-auto p-8 space-y-6">

--- a/web/app/stores/page.tsx
+++ b/web/app/stores/page.tsx
@@ -4,6 +4,7 @@ export default function StoresIndex() {
   const retailers = [
     { id: "bestbuy", name: "Best Buy" },
     { id: "microcenter", name: "Micro Center" },
+    { id: "newegg", name: "Newegg" },
   ];
   return (
     <main className="max-w-3xl mx-auto p-8 space-y-6">

--- a/web/components/SearchFiltersForm.tsx
+++ b/web/components/SearchFiltersForm.tsx
@@ -30,6 +30,7 @@ export default function SearchFiltersForm({ q, retailer, sku, min_condition, pri
           <option value="">All</option>
           <option value="bestbuy">Best Buy</option>
           <option value="microcenter">Micro Center</option>
+          <option value="newegg">Newegg</option>
         </select>
       </div>
       <div>

--- a/web/components/SearchHero.tsx
+++ b/web/components/SearchHero.tsx
@@ -56,6 +56,14 @@ export default function SearchHero({ subtitle }: Props) {
         >Micro Center</button>
         <button
           onClick={() => {
+            const next = retailer === 'newegg' ? '' : 'newegg';
+            setRetailer(next);
+            router.push(`/search?${buildQuery(next, minCondition, q)}`);
+          }}
+          className={`px-3 py-1.5 rounded-full border ${retailer === 'newegg' ? 'bg-brand text-black' : 'bg-white'}`}
+        >Newegg</button>
+        <button
+          onClick={() => {
             const next = minCondition === 'excellent' ? '' : 'excellent';
             setMinCondition(next);
             router.push(`/search?${buildQuery(retailer, next, q)}`);

--- a/web/components/stores/StoreList.tsx
+++ b/web/components/stores/StoreList.tsx
@@ -4,7 +4,7 @@ import StoreRow from "@/components/stores/StoreRow";
 
 type Store = { store_id: string; name: string | null; city: string | null; zipcode: string | null };
 
-export default function StoreList({ retailer, stores }: { retailer: "bestbuy" | "microcenter"; stores: Store[] }) {
+export default function StoreList({ retailer, stores }: { retailer: "bestbuy" | "microcenter" | "newegg"; stores: Store[] }) {
   const [compact, setCompact] = useState(false);
   const [showMap, setShowMap] = useState(false);
   return (

--- a/web/components/stores/StoreRow.tsx
+++ b/web/components/stores/StoreRow.tsx
@@ -5,7 +5,7 @@ import WatchSheet from "@/components/watch/WatchSheet";
 import { Button } from "@/components/ui/button";
 
 type Props = {
-  retailer: "bestbuy" | "microcenter";
+  retailer: "bestbuy" | "microcenter" | "newegg";
   store: { store_id: string; name: string | null; city: string | null; zipcode: string | null };
 };
 

--- a/web/components/watch/WatchSheet.tsx
+++ b/web/components/watch/WatchSheet.tsx
@@ -8,12 +8,12 @@ import { Input } from "@/components/ui/input";
 type Props = {
   open: boolean;
   onOpenChange: (next: boolean) => void;
-  defaults: Partial<WatchPayload> & { retailer?: "bestbuy" | "microcenter" };
+  defaults: Partial<WatchPayload> & { retailer?: "bestbuy" | "microcenter" | "newegg" };
 };
 
 export default function WatchSheet({ open, onOpenChange, defaults }: Props) {
   const { create, loading } = useOptimisticWatch();
-  const [retailer, setRetailer] = useState<"bestbuy" | "microcenter">((defaults.retailer as any) || "bestbuy");
+  const [retailer, setRetailer] = useState<"bestbuy" | "microcenter" | "newegg">((defaults.retailer as any) || "bestbuy");
   const [zipcode, setZipcode] = useState("");
   const [radius, setRadius] = useState(25);
   const [minCondition, setMinCondition] = useState("fair");
@@ -75,6 +75,7 @@ export default function WatchSheet({ open, onOpenChange, defaults }: Props) {
                 <select className="mt-1 w-full border rounded px-3 py-2" value={retailer} onChange={(e) => setRetailer(e.target.value as any)}>
                   <option value="bestbuy">Best Buy</option>
                   <option value="microcenter">Micro Center</option>
+                  <option value="newegg">Newegg</option>
                 </select>
               </div>
               {defaults.sku ? (

--- a/web/lib/hooks/useOptimisticWatch.ts
+++ b/web/lib/hooks/useOptimisticWatch.ts
@@ -3,7 +3,7 @@ import { useState, useCallback } from "react";
 import { toast } from "sonner";
 
 export type WatchPayload = {
-  retailer: "bestbuy" | "microcenter";
+  retailer: "bestbuy" | "microcenter" | "newegg";
   sku?: string;
   product_url?: string;
   keywords?: string[];

--- a/web/lib/utils/parse.ts
+++ b/web/lib/utils/parse.ts
@@ -1,4 +1,4 @@
-export function parseProductUrl(raw: string | null): { retailer?: 'bestbuy'|'microcenter'; sku?: string } | null {
+export function parseProductUrl(raw: string | null): { retailer?: 'bestbuy'|'microcenter'|'newegg'; sku?: string } | null {
   if (!raw) return null;
   let url: URL;
   try { url = new URL(raw); } catch { return null; }
@@ -18,6 +18,13 @@ export function parseProductUrl(raw: string | null): { retailer?: 'bestbuy'|'mic
     const m = url.pathname.match(/product\/(\d{5,9})/i);
     if (m?.[1]) return { retailer: 'microcenter', sku: m[1] };
     return { retailer: 'microcenter' };
+  }
+  if (host.includes('newegg.com')) {
+    const sku = url.searchParams.get('Item') || url.searchParams.get('item');
+    if (sku) return { retailer: 'newegg', sku };
+    const pathMatch = url.pathname.match(/\/([^/]*N[A-Z0-9]{2,})/i);
+    if (pathMatch?.[1]) return { retailer: 'newegg', sku: pathMatch[1].toUpperCase() };
+    return { retailer: 'newegg' };
   }
   return null;
 }

--- a/web/scripts/seed-stores.ts
+++ b/web/scripts/seed-stores.ts
@@ -5,7 +5,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 
 type Row = {
-  retailer: 'bestbuy' | 'microcenter';
+  retailer: 'bestbuy' | 'microcenter' | 'newegg';
   store_id: string;
   name: string;
   zipcode?: string;
@@ -23,7 +23,7 @@ async function run() {
   ];
   const root = roots.find((p) => fs.existsSync(p)) ?? roots[0];
 
-  const files = ['stores.bestbuy.json', 'stores.microcenter.json'];
+  const files = ['stores.bestbuy.json', 'stores.microcenter.json', 'stores.newegg.json'];
   for (const f of files) {
     const rows: Row[] = JSON.parse(fs.readFileSync(path.join(root, f), 'utf8'));
     for (const r of rows) {

--- a/worker/src/adapters/microcenter_dom.ts
+++ b/worker/src/adapters/microcenter_dom.ts
@@ -9,6 +9,7 @@ export type McItem = {
   priceCents: number;
   url: string;
   seenAt: string;
+  imageUrl?: string;
 };
 
 function toStoreSlug(storeId: string): string {
@@ -21,55 +22,109 @@ function parsePriceToCents(text: string): number | null {
   return Math.round(parseFloat(m[1]) * 100);
 }
 
+function parseSkuFromUrl(raw: string): string | undefined {
+  try {
+    const url = new URL(raw);
+    const qs = url.searchParams.get('sku');
+    if (qs) return qs;
+    const parts = url.pathname.split('/').filter(Boolean);
+    const idx = parts.findIndex((p) => p.toLowerCase() === 'product');
+    if (idx >= 0 && parts[idx + 1]) {
+      const next = parts[idx + 1];
+      const sku = next.replace(/[^0-9]/g, '');
+      if (sku) return sku;
+    }
+    const last = parts[parts.length - 1];
+    if (last) {
+      const digits = last.replace(/[^0-9]/g, '');
+      if (digits) return digits;
+    }
+  } catch {}
+  return undefined;
+}
+
+function normalizeImage(url: string | null | undefined, base: string): string | undefined {
+  if (!url) return undefined;
+  const trimmed = url.trim();
+  if (!trimmed) return undefined;
+  if (trimmed.startsWith('//')) return `https:${trimmed}`;
+  if (/^https?:/i.test(trimmed)) return trimmed;
+  try {
+    return new URL(trimmed, base).toString();
+  } catch {}
+  return undefined;
+}
+
 export async function fetchMicroCenterOpenBoxDOM(storeId: string): Promise<{ storeId: string; items: McItem[] }> {
   const slug = toStoreSlug(storeId);
   const now = new Date().toISOString();
   const items: McItem[] = [];
+  const seen = new Set<string>();
 
   const candidates: string[] = [
     `https://www.microcenter.com/search/search_results.aspx?Ntt=open%20box&storeid=${encodeURIComponent(slug)}`,
+    `https://www.microcenter.com/search/search_results.aspx?Ntt=open-box&storeid=${encodeURIComponent(slug)}`,
     `https://www.microcenter.com/site/stores/${encodeURIComponent(slug)}.aspx`,
   ];
 
   for (const url of candidates) {
     try {
-      const res = await fetch(url, { headers: { 'user-agent': 'Mozilla/5.0 (compatible; OpenboxRadar/0.3)' } });
+      const res = await fetch(url, { headers: { 'user-agent': 'Mozilla/5.0 (compatible; OpenboxRadar/0.4)' } });
       if (!res.ok) continue;
       const html = await res.text();
       const { document } = parseHTML(html);
 
       const cards = document.querySelectorAll(
-        '.product_wrapper, .product, .product_tile, .products .product, .productGrid .product, li.product'
+        '.product_wrapper, .product, .product_tile, .products .product, .productGrid .product, li.product, .productGridItem'
       );
 
       for (const card of cards as any) {
         const a = card.querySelector('a[href*="/product/"]') || card.querySelector('a[href]');
-        const titleEl = card.querySelector('.product_title, .details .name, .product_name, a');
-        const priceEl = card.querySelector('.price, .price .value, [class*="price"]');
+        const titleEl = card.querySelector('.product_title, .details .name, .product_name, .productTitle, a');
+        const priceEl = card.querySelector('.price, .price .value, [class*="price"], .price-wrapper');
+        const conditionEl =
+          card.querySelector('.product_condition, .condition, .productCondition') || card.querySelector('.product_promo');
+        const imgEl = card.querySelector('img');
 
         const href = a?.getAttribute('href') || '';
-        const title = (titleEl?.textContent || a?.textContent || '').trim();
+        const title = (titleEl?.textContent || a?.textContent || '').replace(/\s+/g, ' ').trim();
         const priceText = (priceEl?.textContent || '').trim();
         const priceCents = parsePriceToCents(priceText || '');
 
         if (!href || !title || !priceCents) continue;
         const prodUrl = new URL(href, url).toString();
+        const sku = parseSkuFromUrl(prodUrl);
+        const key = sku || prodUrl;
+        if (seen.has(key)) continue;
+        seen.add(key);
+
+        const condition =
+          (conditionEl?.textContent || '').trim() ||
+          (title.toLowerCase().includes('refurb') ? 'Refurbished/Open-Box' : 'Open-Box');
+
+        const imageUrl =
+          imgEl?.getAttribute('data-src') ||
+          imgEl?.getAttribute('srcset')?.split(' ')?.[0] ||
+          imgEl?.getAttribute('src') ||
+          undefined;
 
         items.push({
           retailer: 'microcenter',
           storeId,
+          sku,
           title,
-          conditionLabel: 'Open-Box',
+          conditionLabel: condition,
           priceCents,
           url: prodUrl,
           seenAt: now,
+          imageUrl: normalizeImage(imageUrl, prodUrl),
         });
-        if (items.length >= 50) break;
+        if (items.length >= 60) break;
       }
 
       if (items.length) break; // got something
-    } catch {
-      // Try next candidate
+    } catch (err) {
+      console.warn('[microcenter] fetch failed for', storeId, url, err);
     }
   }
 

--- a/worker/src/adapters/newegg_clearance.ts
+++ b/worker/src/adapters/newegg_clearance.ts
@@ -1,14 +1,191 @@
+import { parseHTML } from 'linkedom';
 import type { NormalizedItem } from './types';
 
-// Placeholder/stub for Newegg clearance adapter.
-// In dev (USE_REAL_NEWEGG != '1') this returns an empty list to keep the pipeline running.
+const STORE_ID = 'newegg-online';
+const LISTING_URL = 'https://www.newegg.com/d/Open-Box?PageSize=96';
+const USER_AGENT = 'Mozilla/5.0 (compatible; OpenboxRadar/0.4; +https://openboxradar.com)';
+
+function parsePriceToCents(text: string): number | null {
+  const cleaned = text.replace(/[\s,$]/g, '').replace(/\.([0-9])$/, '.$10');
+  const match = cleaned.match(/(\d+)(?:\.(\d{2}))?/);
+  if (!match) return null;
+  const dollars = Number(match[1]);
+  const cents = match[2] ? Number(match[2]) : 0;
+  if (Number.isNaN(dollars) || Number.isNaN(cents)) return null;
+  return dollars * 100 + cents;
+}
+
+function normalizeImage(url: string | null | undefined, base: string): string | undefined {
+  if (!url) return undefined;
+  const trimmed = url.trim();
+  if (!trimmed) return undefined;
+  if (trimmed.startsWith('//')) return `https:${trimmed}`;
+  if (/^https?:/i.test(trimmed)) return trimmed;
+  try {
+    return new URL(trimmed, base).toString();
+  } catch {}
+  return undefined;
+}
+
+function parseSkuFromUrl(raw: string): string | null {
+  try {
+    const url = new URL(raw);
+    const fromQuery = url.searchParams.get('Item') || url.searchParams.get('item');
+    if (fromQuery) return fromQuery;
+    const parts = url.pathname.split('/').filter(Boolean);
+    if (parts.length) {
+      const last = parts[parts.length - 1];
+      const skuMatch = last.match(/(N[0-9A-Z]{2,})/i);
+      if (skuMatch?.[1]) return skuMatch[1].toUpperCase();
+    }
+  } catch {}
+  return null;
+}
 
 export async function fetchNeweggClearance(useReal: boolean): Promise<{ storeId: string; items: NormalizedItem[] }> {
   if (!useReal) {
-    return { storeId: 'newegg-online', items: [] };
+    return { storeId: STORE_ID, items: [] };
   }
-  // TODO: Implement real DOM/API fetch if/when available
-  // Keep returning empty for now to satisfy interface and scheduler expectations
-  return { storeId: 'newegg-online', items: [] };
+
+  const now = new Date().toISOString();
+  const items: NormalizedItem[] = [];
+  const seen = new Set<string>();
+
+  try {
+    const res = await fetch(LISTING_URL, {
+      headers: {
+        'user-agent': USER_AGENT,
+        'accept-language': 'en-US,en;q=0.9',
+      },
+    });
+    if (!res.ok) {
+      console.warn('[newegg] listing fetch failed', res.status, res.statusText);
+      return { storeId: STORE_ID, items: [] };
+    }
+
+    const html = await res.text();
+    const { document } = parseHTML(html);
+
+    const cards = document.querySelectorAll(
+      '.item-cell, .swiper-slide .item-cell, .item-container, .item-content, .slick-slide .item-cell'
+    );
+
+    for (const card of cards as any) {
+      const link = card.querySelector('a.item-title') || card.querySelector('a[href*="/Product/"]');
+      const href = link?.getAttribute('href');
+      const title = (link?.textContent || '').trim();
+      if (!href || !title) continue;
+
+      const priceEl =
+        card.querySelector('.price-current') ||
+        card.querySelector('.price') ||
+        card.querySelector('[class*="price"][class*="current"]');
+      let priceText = (priceEl?.textContent || '').trim();
+      if (!priceText) {
+        const strong = card.querySelector('.price-current strong');
+        const sup = card.querySelector('.price-current sup');
+        if (strong) {
+          priceText = `${strong.textContent || ''}${sup?.textContent || ''}`;
+        }
+      }
+      let priceCents = parsePriceToCents(priceText);
+      if (priceCents == null) {
+        const dollarsText = (card.querySelector('.price-current strong')?.textContent || '').replace(/[^0-9]/g, '');
+        const centsRaw = (card.querySelector('.price-current sup')?.textContent || '').replace(/[^0-9]/g, '');
+        if (dollarsText) {
+          const centsPart = centsRaw ? centsRaw.padEnd(2, '0').slice(0, 2) : '00';
+          priceCents = Number(dollarsText) * 100 + Number(centsPart);
+        }
+      }
+      if (priceCents == null || Number.isNaN(priceCents)) continue;
+
+      const absoluteUrl = new URL(href, LISTING_URL).toString();
+      const sku = parseSkuFromUrl(absoluteUrl);
+      const key = sku || absoluteUrl;
+      if (seen.has(key)) continue;
+      seen.add(key);
+
+      const condition =
+        (card.querySelector('.item-promo')?.textContent ||
+          card.querySelector('[class*="promo"]')?.textContent ||
+          card.querySelector('.item-operating-condition')?.textContent ||
+          'Open-Box')
+          .replace(/\s+/g, ' ')
+          .trim() || 'Open-Box';
+
+      const imgEl = card.querySelector('img');
+      const imageUrl =
+        imgEl?.getAttribute('data-src') ||
+        imgEl?.getAttribute('data-original') ||
+        imgEl?.getAttribute('src') ||
+        undefined;
+
+      items.push({
+        retailer: 'newegg',
+        storeId: STORE_ID,
+        sku: sku ?? undefined,
+        title,
+        conditionLabel: condition,
+        priceCents,
+        url: absoluteUrl,
+        seenAt: now,
+        imageUrl: normalizeImage(imageUrl, absoluteUrl),
+      });
+
+      if (items.length >= 80) break;
+    }
+
+    if (!items.length) {
+      // Fallback: attempt to parse embedded JSON containing product info.
+      const jsonMatches = html.match(/__INITIAL_STATE__\s*=\s*(\{.*?\})\s*;<\/script>/s);
+      if (jsonMatches?.[1]) {
+        try {
+          const data = JSON.parse(jsonMatches[1]);
+          const list = data?.pageData?.items || data?.productList || [];
+          if (Array.isArray(list)) {
+            for (const entry of list) {
+              const title = entry?.title || entry?.itemTitle;
+              const urlRaw = entry?.itemUrl || entry?.productUrl;
+              const price = entry?.finalPrice || entry?.price || entry?.pricing?.finalPrice;
+              if (!title || !urlRaw || !price) continue;
+              const numericPrice = Number(price);
+              if (!Number.isFinite(numericPrice)) continue;
+              const priceCents = Math.round(numericPrice * 100);
+              const resolvedUrl = (() => {
+                try {
+                  return new URL(urlRaw, LISTING_URL).toString();
+                } catch {
+                  return typeof urlRaw === 'string' ? urlRaw : '';
+                }
+              })();
+              if (!priceCents) continue;
+              const sku = entry?.itemNumber || entry?.itemNumberOverride;
+              const key = sku || resolvedUrl;
+              if (seen.has(key)) continue;
+              seen.add(key);
+              items.push({
+                retailer: 'newegg',
+                storeId: STORE_ID,
+                sku: sku ?? undefined,
+                title: String(title).trim(),
+                conditionLabel: 'Open-Box',
+                priceCents,
+                url: resolvedUrl,
+                seenAt: now,
+                imageUrl: normalizeImage(entry?.imageUrl || entry?.image, resolvedUrl),
+              });
+              if (items.length >= 80) break;
+            }
+          }
+        } catch (err) {
+          console.warn('[newegg] json fallback parse failed', err);
+        }
+      }
+    }
+  } catch (err) {
+    console.warn('[newegg] fetch failed', err);
+  }
+
+  return { storeId: STORE_ID, items };
 }
 

--- a/worker/src/scheduler.ts
+++ b/worker/src/scheduler.ts
@@ -57,10 +57,26 @@ export const Scheduler = {
     const useRealBBY = env.USE_REAL_BESTBUY === '1';
     const allowDevStubs = env.ALLOW_DEV_STUBS === '1';
 
+    const adapterPromises: Array<Promise<{ storeId: string; items: any[] }>> = [];
+
     // Micro Center
-    const mcPromise = useRealMC
-      ? fetchMicroCenterOpenBoxDOM('mc-cambridge')
-      : (allowDevStubs ? fetchMicroCenterStore('mc-cambridge') : Promise.resolve({ storeId: 'mc-disabled', items: [] as any[] }));
+    if (useRealMC) {
+      const rawStoreIds = String(env.MICROCENTER_STORE_IDS || 'mc-cambridge')
+        .split(',')
+        .map((s: string) => s.trim())
+        .filter(Boolean);
+      const storeIds = rawStoreIds.length ? rawStoreIds : ['mc-cambridge'];
+      for (const id of storeIds) {
+        adapterPromises.push(
+          fetchMicroCenterOpenBoxDOM(id).catch((err) => {
+            console.warn('[scheduler] microcenter fetch failed', id, err);
+            return { storeId: id, items: [] as any[] };
+          })
+        );
+      }
+    } else if (allowDevStubs) {
+      adapterPromises.push(fetchMicroCenterStore('mc-cambridge'));
+    }
 
     let bbyPromise: Promise<{ storeId: string; items: any[] }>;
     if (useRealBBY) {
@@ -81,19 +97,25 @@ export const Scheduler = {
     } else {
       bbyPromise = allowDevStubs ? fetchBestBuyStore('bby-123') : Promise.resolve({ storeId: 'bby-disabled', items: [] });
     }
+    adapterPromises.push(bbyPromise);
 
     const useRealNE = env.USE_REAL_NEWEGG === '1';
-    const nePromise = fetchNeweggClearance(useRealNE);
+    adapterPromises.push(
+      fetchNeweggClearance(useRealNE).catch((err) => {
+        console.warn('[scheduler] newegg fetch failed', err);
+        return { storeId: 'newegg-online', items: [] as any[] };
+      })
+    );
 
     const enrichment = await refreshBestBuyForHotWatches(env);
 
-    const batches = await Promise.all([bbyPromise, mcPromise, nePromise]);
+    const batches = await Promise.all(adapterPromises);
 
     const items = batches.flatMap((b) => b.items);
     const sources = batches.map((b) => ({ storeId: (b as any)?.storeId || 'unknown', count: b.items?.length ?? 0 }));
-    console.log('[scheduler] flags:', { useRealBBY, useRealMC, allowDevStubs });
+    console.log('[scheduler] flags:', { useRealBBY, useRealMC, useRealNE, allowDevStubs });
     console.log('[scheduler] adapter batches:', sources.map((s) => `${s.storeId}:${s.count}`).join(', '));
-    if (items.length === 0) return { ok: true, ingested: 0, flags: { useRealBBY, useRealMC, allowDevStubs }, sources } as any;
+    if (items.length === 0) return { ok: true, ingested: 0, flags: { useRealBBY, useRealMC, useRealNE, allowDevStubs }, sources } as any;
 
     const ingestUrl: string = env.INGEST_URL || '';
     if (!ingestUrl) return { ok: false, error: 'INGEST_URL not set', ingested: 0 };
@@ -109,9 +131,9 @@ export const Scheduler = {
       });
 
       const json = await r.json().catch(() => ({}));
-      return { ok: r.ok, status: r.status, ingested: json.inserted ?? 0, flags: { useRealBBY, useRealMC, allowDevStubs }, sources, enrichment } as any;
+      return { ok: r.ok, status: r.status, ingested: json.inserted ?? 0, flags: { useRealBBY, useRealMC, useRealNE, allowDevStubs }, sources, enrichment } as any;
     } catch (e: any) {
-      return { ok: false, error: e?.message || String(e), step: 'ingest', ingestUrl, flags: { useRealBBY, useRealMC, allowDevStubs }, sources, enrichment } as any;
+      return { ok: false, error: e?.message || String(e), step: 'ingest', ingestUrl, flags: { useRealBBY, useRealMC, useRealNE, allowDevStubs }, sources, enrichment } as any;
     }
   }
 }

--- a/worker/wrangler.toml
+++ b/worker/wrangler.toml
@@ -15,6 +15,7 @@ enabled = true
 # If your Next runs on :3001, change to http://localhost:3001/api/ingest
 INGEST_URL = "https://openboxradar.com/api/ingest"
 USE_REAL_MICROCENTER = "1"
+MICROCENTER_STORE_IDS = "mc-cambridge"
 USE_REAL_BESTBUY = "1"
 USE_REAL_NEWEGG = "0"
 ALLOW_DEV_STUBS = "0"


### PR DESCRIPTION
## Summary
- implement a real Newegg open-box scraper and integrate it with the worker scheduler
- enhance the Micro Center DOM adapter to capture richer data and support multi-store polling via configuration
- allow the web app, ingest endpoint, and seed scripts to recognise Newegg as a retailer and surface it in filters and watch flows

## Testing
- `pnpm lint` *(fails: prompts for ESLint config in this repo)*

------
https://chatgpt.com/codex/tasks/task_e_68cefda8f2b0832b9173315c96549d59