### PR TITLE
fix: preserve newegg data in production

### DIFF
--- a/scripts/seed_dev_items.js
+++ b/scripts/seed_dev_items.js
@@ -28,7 +28,7 @@ async function main() {
     },
     {
       retailer: 'newegg',
-      storeId: 'newegg-online',
+      storeId: 'newegg-stub',
       sku: 'DEV-NE-001',
       title: 'DEV Newegg Open-Box GPU',
       conditionLabel: 'Open-Box',

--- a/web/app/api/ingest/route.ts
+++ b/web/app/api/ingest/route.ts
@@ -45,7 +45,7 @@ export async function POST(req: NextRequest) {
   const isDevLike = (it: z.infer<typeof Item>) => {
     const titleLooksDev = /^\s*DEV\b/i.test(it.title);
     const urlLooksDev = /example\.com/i.test(it.url);
-    const devStores = new Set(['bby-123', 'mc-cambridge', 'newegg-online']);
+    const devStores = new Set(['bby-123', 'mc-cambridge', 'newegg-stub']);
     const storeLooksDev = devStores.has(it.storeId);
     return titleLooksDev || urlLooksDev || storeLooksDev;
   };

--- a/worker/src/adapters/newegg_clearance.ts
+++ b/worker/src/adapters/newegg_clearance.ts
@@ -2,6 +2,7 @@ import { parseHTML } from 'linkedom';
 import type { NormalizedItem } from './types';
 
 const STORE_ID = 'newegg-online';
+const STUB_STORE_ID = 'newegg-stub';
 const LISTING_URL = 'https://www.newegg.com/d/Open-Box?PageSize=96';
 const USER_AGENT = 'Mozilla/5.0 (compatible; OpenboxRadar/0.4; +https://openboxradar.com)';
 
@@ -44,7 +45,7 @@ function parseSkuFromUrl(raw: string): string | null {
 
 export async function fetchNeweggClearance(useReal: boolean): Promise<{ storeId: string; items: NormalizedItem[] }> {
   if (!useReal) {
-    return { storeId: STORE_ID, items: [] };
+    return { storeId: STUB_STORE_ID, items: [] };
   }
 
   const now = new Date().toISOString();


### PR DESCRIPTION
## Summary
- stop treating the real Newegg store id as a dev stub during ingest
- return a dedicated Newegg stub id when the adapter runs in dev mode
- update the dev seeding script to use the new stub id

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cf0470394c832b89c48f1ff7955b32