### PR TITLE
Simplify search page fetch cache options

### DIFF
--- a/web/app/search/page.tsx
+++ b/web/app/search/page.tsx
@@ -76,8 +76,6 @@ export default async function SearchPage({ searchParams }: { searchParams: Recor
 
   const res = await fetch(absoluteUrl('/api/inventory/search') + '?' + qp.toString(), {
     cache: "no-store",
-    // Ensure server fetch regardless of deployment
-    next: { revalidate: 0 },
   });
   const data = (await res.json()) as { items: Item[]; nextCursor?: string | null };
 


### PR DESCRIPTION
## Summary
- remove redundant revalidate directive from the search page fetch call
- rely solely on the existing no-store cache option for the inventory search request

## Testing
- pnpm lint *(fails: command prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68cf14b84674832bb4f7de6e92e9e181