### PR TITLE
Add store scrapers and debug instrumentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,13 @@ pnpm install
 pnpm dev   # http://127.0.0.1:8787
 ```
 
+> Store scrapers rely on Playwright. Install `playwright-core` alongside the worker package when enabling them:
+>
+> ```bash
+> cd worker
+> pnpm add playwright-core
+> ```
+
 5) Configure Worker for real Best Buy data
    - In `worker/wrangler.toml` set:
      - `USE_REAL_BESTBUY = "1"`
@@ -94,6 +101,10 @@ Worker (`worker/wrangler.toml` / secrets)
 - Source selection: `BESTBUY_SKUS` or `BESTBUY_CATEGORY` (with `BESTBUY_PAGE_SIZE`)
 - `USE_REAL_MICROCENTER` — optional, `1` to scrape DOM
 - `MICROCENTER_STORE_IDS` — comma list of store ids (e.g. `mc-cambridge,mc-brooklyn`)
+- `ENABLE_MC_STORE_SCRAPE`, `ENABLE_BB_STORE_SCRAPE` — toggle Playwright store scrapers (requires `playwright-core` in `worker`)
+- `PLAYWRIGHT_HEADLESS` — set to `0` for headed debugging of Playwright runs
+- `MICROCENTER_RATE_LIMIT_MS`, `BESTBUY_RATE_LIMIT_MS` — delay between store page fetches
+- `BESTBUY_STORE_IDS` — comma list of Best Buy store identifiers (`bby-123@https://...` to override URLs)
 - `USE_REAL_NEWEGG` — `1` to scrape Newegg open-box listings
 - `ENABLE_BB_ENRICHMENT`, `BB_ENRICHMENT_TTL_MIN`, `BB_ENRICHMENT_FAIL_TTL_MIN`, `BB_MAX_ENRICH_RPS`
 

--- a/web/app/api/debug/source-counts/route.ts
+++ b/web/app/api/debug/source-counts/route.ts
@@ -1,0 +1,14 @@
+import { NextResponse } from 'next/server';
+import { db } from '@/lib/drizzle/db';
+import { sql } from 'drizzle-orm';
+
+export async function GET() {
+  const rows = await db.execute(sql`
+    SELECT source, channel, confidence, COUNT(*)::int AS count
+    FROM inventory
+    WHERE seen_at > NOW() - INTERVAL '36 hours'
+    GROUP BY source, channel, confidence
+    ORDER BY count DESC
+  `);
+  return NextResponse.json({ rows: rows.rows ?? [] });
+}

--- a/web/app/api/ingest/route.ts
+++ b/web/app/api/ingest/route.ts
@@ -14,6 +14,12 @@ const Item = z.object({
   url: z.string().url(),
   seenAt: z.string().datetime().optional(),
   imageUrl: z.string().url().optional(),
+  source: z.string().min(1).optional(),
+  channel: z.enum(['store','online']).optional(),
+  confidence: z.enum(['api','scrape','heuristic']).optional(),
+  storeName: z.string().optional(),
+  storeCity: z.string().optional(),
+  storeState: z.string().optional(),
 });
 
 const Payload = z.object({ items: z.array(Item).max(1000) });
@@ -88,6 +94,9 @@ export async function POST(req: NextRequest) {
       url: it.url,
       seen_at: seenAt,
       image_url: it.imageUrl ?? null,
+      source: it.source ?? `${it.retailer}-${it.storeId}`,
+      channel: (it.channel ?? 'store') as any,
+      confidence: (it.confidence ?? 'scrape') as any,
     }).onConflictDoNothing();
     // Append to price history (best effort)
     try {

--- a/web/lib/drizzle/schema.ts
+++ b/web/lib/drizzle/schema.ts
@@ -74,6 +74,8 @@ export const inventory = pgTable('inventory', {
   image_url: text('image_url'),
   // Best Buy TTL fields
   source: text('source').notNull().default('microcenter'),
+  channel: text('channel').notNull().default('store'),
+  confidence: text('confidence').notNull().default('scrape'),
   fetched_at: timestamp('fetched_at', { withTimezone: true }).notNull().defaultNow(),
   expires_at: timestamp('expires_at', { withTimezone: true }),
 });

--- a/worker/src/global.d.ts
+++ b/worker/src/global.d.ts
@@ -1,0 +1,5 @@
+declare module 'playwright-core' {
+  export const chromium: {
+    launch(options?: any): Promise<any>;
+  };
+}

--- a/worker/src/ingest.ts
+++ b/worker/src/ingest.ts
@@ -1,0 +1,61 @@
+export type IngestPayload = {
+  retailer: 'bestbuy' | 'microcenter' | 'newegg' | string;
+  storeId: string;
+  sku?: string;
+  title: string;
+  conditionLabel: string;
+  priceCents: number;
+  url: string;
+  seenAt?: string;
+  imageUrl?: string;
+  source?: string;
+  channel?: string;
+  confidence?: string;
+  storeName?: string;
+  storeCity?: string;
+  storeState?: string;
+  expiresAt?: string;
+};
+
+export async function postIngest(
+  items: IngestPayload[],
+  opts: { ingestUrl?: string; secret?: string }
+): Promise<{ status: number; inserted: number; body: any }> {
+  if (!items.length) {
+    return { status: 204, inserted: 0, body: null };
+  }
+
+  const ingestUrl = opts.ingestUrl;
+  const secret = opts.secret;
+
+  if (!ingestUrl) {
+    throw new Error('Missing INGEST_URL');
+  }
+  if (!secret) {
+    throw new Error('Missing CRON_SHARED_SECRET');
+  }
+
+  const resp = await fetch(ingestUrl, {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      authorization: `Bearer ${secret}`,
+    },
+    body: JSON.stringify({ items }),
+  });
+
+  let body: any = null;
+  try {
+    body = await resp.json();
+  } catch {
+    body = await resp.text();
+  }
+
+  if (!resp.ok) {
+    const message = typeof body === 'string' ? body : JSON.stringify(body);
+    throw new Error(`Ingest failed ${resp.status}: ${message}`);
+  }
+
+  const inserted = typeof body?.inserted === 'number' ? body.inserted : Array.isArray(body?.items) ? body.items.length : 0;
+  return { status: resp.status, inserted, body };
+}

--- a/worker/src/scheduler.ts
+++ b/worker/src/scheduler.ts
@@ -1,8 +1,12 @@
-import { fetchBestBuyStore, fetchMicroCenterStore } from "./adapters/stubs";
-import { fetchMicroCenterOpenBoxDOM } from "./adapters/microcenter_dom";
-import { fetchBestBuyOpenBoxBySkus, fetchBestBuyOpenBoxByCategory } from "./adapters/bestbuy_api";
-import { fetchNeweggClearance } from "./adapters/newegg_clearance";
-import { getBestBuyStoreAvailability } from "./enrichers/bestbuy_store_availability";
+import { fetchBestBuyStore, fetchMicroCenterStore } from './adapters/stubs';
+import { fetchBestBuyOpenBoxBySkus, fetchBestBuyOpenBoxByCategory } from './adapters/bestbuy_api';
+import { fetchMicroCenterOpenBoxDOM } from './adapters/microcenter_dom';
+import { fetchNeweggClearance } from './adapters/newegg_clearance';
+import { getBestBuyStoreAvailability } from './enrichers/bestbuy_store_availability';
+import { scrapeMicroCenterStores } from './sources/microcenter/storeScraper';
+import { scrapeBestBuyStores } from './sources/bestbuy/storeScraper';
+import type { StoreConfig } from './sources/types';
+import { postIngest, type IngestPayload } from './ingest';
 
 function baseUrlFromIngest(ingestUrl: string): string {
   try {
@@ -14,6 +18,86 @@ function baseUrlFromIngest(ingestUrl: string): string {
   } catch {
     return '';
   }
+}
+
+function titleCase(input: string): string {
+  return input
+    .split(' ')
+    .map((word) => (word ? word[0].toUpperCase() + word.slice(1) : ''))
+    .join(' ')
+    .trim();
+}
+
+function buildMicroCenterStore(id: string): StoreConfig {
+  const slug = id.replace(/^mc-/, '');
+  const label = slug.replace(/-/g, ' ');
+  return {
+    id,
+    name: titleCase(`Micro Center ${label || id}`),
+    url: `https://www.microcenter.com/site/stores/${slug}-open-box.aspx`,
+  };
+}
+
+function buildBestBuyStore(id: string): StoreConfig {
+  const numeric = id.replace(/^bby-/, '');
+  return {
+    id,
+    name: `Best Buy ${numeric}`,
+    url: `https://www.bestbuy.com/site/searchpage.jsp?st=open+box&cp=1&qp=storepickupsameasstoreid_facet%3DStorePickUpSameAsStoreId_facet%3D${numeric}`,
+  };
+}
+
+function parseStoreConfigs(
+  raw: string | undefined,
+  fallback: string[],
+  builder: (id: string) => StoreConfig
+): StoreConfig[] {
+  const entries = (raw || '')
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean);
+  const source = entries.length ? entries : fallback;
+  return source.map((entry) => {
+    const [meta, urlOverride] = entry.split('@');
+    const parts = meta
+      .split('|')
+      .map((s) => s.trim())
+      .filter(Boolean);
+    const id = parts[0];
+    const store = builder(id);
+    if (parts[1]) store.name = parts[1];
+    if (parts[2]) store.city = parts[2];
+    if (parts[3]) store.state = parts[3];
+    if (urlOverride) store.url = urlOverride.trim();
+    return store;
+  });
+}
+
+function mapLegacyItems(items: any[], meta: Partial<IngestPayload>): IngestPayload[] {
+  return items
+    .map((item) => {
+      if (!item) return null;
+      const seenAt = item.seenAt || new Date().toISOString();
+      const condition = item.conditionLabel || meta.conditionLabel || 'Open-Box';
+      return {
+        retailer: item.retailer || meta.retailer || 'unknown',
+        storeId: item.storeId || meta.storeId || 'unknown',
+        sku: item.sku || undefined,
+        title: item.title,
+        conditionLabel: condition,
+        priceCents: item.priceCents,
+        url: item.url,
+        seenAt,
+        imageUrl: item.imageUrl,
+        source: meta.source,
+        channel: meta.channel,
+        confidence: meta.confidence,
+        storeName: meta.storeName,
+        storeCity: meta.storeCity,
+        storeState: meta.storeState,
+      } satisfies IngestPayload;
+    })
+    .filter(Boolean) as IngestPayload[];
 }
 
 async function refreshBestBuyForHotWatches(env: any) {
@@ -52,88 +136,186 @@ async function refreshBestBuyForHotWatches(env: any) {
 
 export const Scheduler = {
   async run(env: any) {
-    // Flags
-    const useRealMC = env.USE_REAL_MICROCENTER === '1';
-    const useRealBBY = env.USE_REAL_BESTBUY === '1';
     const allowDevStubs = env.ALLOW_DEV_STUBS === '1';
+    const enableMicroCenterStore = env.ENABLE_MC_STORE_SCRAPE === '1';
+    const enableBestBuyStore = env.ENABLE_BB_STORE_SCRAPE === '1';
+    const useBestBuyApi = env.USE_REAL_BESTBUY === '1';
+    const useMicroCenterDom = env.USE_REAL_MICROCENTER === '1';
+    const useNewegg = env.USE_REAL_NEWEGG === '1';
 
-    const adapterPromises: Array<Promise<{ storeId: string; items: any[] }>> = [];
+    const headless = env.PLAYWRIGHT_HEADLESS !== '0';
+    const ingestItems: IngestPayload[] = [];
+    const sources: Array<{ storeId: string; count: number; url?: string }> = [];
 
-    // Micro Center
-    if (useRealMC) {
-      const rawStoreIds = String(env.MICROCENTER_STORE_IDS || 'mc-cambridge')
-        .split(',')
-        .map((s: string) => s.trim())
-        .filter(Boolean);
-      const storeIds = rawStoreIds.length ? rawStoreIds : ['mc-cambridge'];
-      for (const id of storeIds) {
-        adapterPromises.push(
-          fetchMicroCenterOpenBoxDOM(id).catch((err) => {
-            console.warn('[scheduler] microcenter fetch failed', id, err);
-            return { storeId: id, items: [] as any[] };
-          })
-        );
+    // Micro Center store scrape
+    if (enableMicroCenterStore) {
+      const stores = parseStoreConfigs(env.MICROCENTER_STORE_IDS, ['mc-cambridge'], buildMicroCenterStore);
+      const mcResult = await scrapeMicroCenterStores(stores, {
+        headless,
+        rateLimitMs: Number(env.MICROCENTER_RATE_LIMIT_MS || '1000'),
+      }).catch((err) => {
+        console.warn('[scheduler] microcenter scrape failed', err);
+        return { items: [], metrics: [] };
+      });
+      ingestItems.push(...mcResult.items);
+      mcResult.metrics.forEach((m) => sources.push({ storeId: m.storeId, count: m.count, url: m.url }));
+    } else if (useMicroCenterDom) {
+      const storeIds = parseStoreConfigs(env.MICROCENTER_STORE_IDS, ['mc-cambridge'], buildMicroCenterStore);
+      for (const store of storeIds) {
+        try {
+          const batch = await fetchMicroCenterOpenBoxDOM(store.id);
+          ingestItems.push(
+            ...mapLegacyItems(batch.items, {
+              source: 'microcenter-dom',
+              channel: 'store',
+              confidence: 'scrape',
+              retailer: 'microcenter',
+              storeId: store.id,
+              storeName: store.name,
+              storeCity: store.city,
+              storeState: store.state,
+            })
+          );
+          sources.push({ storeId: store.id, count: batch.items.length });
+        } catch (err) {
+          console.warn('[scheduler] microcenter dom fallback failed', store.id, err);
+        }
       }
     } else if (allowDevStubs) {
-      adapterPromises.push(fetchMicroCenterStore('mc-cambridge'));
+      const stub = await fetchMicroCenterStore('mc-cambridge');
+      ingestItems.push(
+        ...mapLegacyItems(stub.items, {
+          source: 'microcenter-stub',
+          channel: 'store',
+          confidence: 'heuristic',
+        })
+      );
+      sources.push({ storeId: 'mc-cambridge', count: stub.items.length });
     }
 
-    let bbyPromise: Promise<{ storeId: string; items: any[] }>;
-    if (useRealBBY) {
+    // Best Buy store scrape
+    if (enableBestBuyStore) {
+      const stores = parseStoreConfigs(env.BESTBUY_STORE_IDS, ['bby-123'], buildBestBuyStore);
+      const bbResult = await scrapeBestBuyStores(stores, {
+        headless,
+        rateLimitMs: Number(env.BESTBUY_RATE_LIMIT_MS || '900'),
+      }).catch((err) => {
+        console.warn('[scheduler] bestbuy store scrape failed', err);
+        return { items: [], metrics: [] };
+      });
+      ingestItems.push(...bbResult.items);
+      bbResult.metrics.forEach((m) => sources.push({ storeId: m.storeId, count: m.count, url: m.url }));
+    } else if (useBestBuyApi) {
       const apiKey: string = env.BESTBUY_API_KEY || '';
       const skus = String(env.BESTBUY_SKUS || '')
         .split(',')
         .map((s: string) => s.trim())
         .filter(Boolean);
       const category: string = env.BESTBUY_CATEGORY || '';
-      if (skus.length) {
-        bbyPromise = fetchBestBuyOpenBoxBySkus(apiKey, skus);
-      } else if (category) {
-        bbyPromise = fetchBestBuyOpenBoxByCategory(apiKey, category, Number(env.BESTBUY_PAGE_SIZE || 50));
-      } else {
-        // No inputs provided; return empty
-        bbyPromise = Promise.resolve({ storeId: 'bby-online', items: [] });
+      let apiItems: IngestPayload[] = [];
+      try {
+        if (skus.length) {
+          const result = await fetchBestBuyOpenBoxBySkus(apiKey, skus);
+          apiItems = mapLegacyItems(result.items, {
+            source: 'bestbuy-online',
+            channel: 'online',
+            confidence: 'api',
+          });
+          sources.push({ storeId: result.storeId, count: result.items.length });
+        } else if (category) {
+          const result = await fetchBestBuyOpenBoxByCategory(apiKey, category, Number(env.BESTBUY_PAGE_SIZE || 50));
+          apiItems = mapLegacyItems(result.items, {
+            source: 'bestbuy-online',
+            channel: 'online',
+            confidence: 'api',
+          });
+          sources.push({ storeId: result.storeId, count: result.items.length });
+        }
+      } catch (err) {
+        console.warn('[scheduler] bestbuy api fetch failed', err);
       }
-    } else {
-      bbyPromise = allowDevStubs ? fetchBestBuyStore('bby-123') : Promise.resolve({ storeId: 'bby-disabled', items: [] });
+      ingestItems.push(...apiItems);
+    } else if (allowDevStubs) {
+      const stub = await fetchBestBuyStore('bby-123');
+      ingestItems.push(
+        ...mapLegacyItems(stub.items, {
+          source: 'bestbuy-stub',
+          channel: 'store',
+          confidence: 'heuristic',
+        })
+      );
+      sources.push({ storeId: 'bby-123', count: stub.items.length });
     }
-    adapterPromises.push(bbyPromise);
 
-    const useRealNE = env.USE_REAL_NEWEGG === '1';
-    adapterPromises.push(
-      fetchNeweggClearance(useRealNE).catch((err) => {
-        console.warn('[scheduler] newegg fetch failed', err);
-        return { storeId: 'newegg-online', items: [] as any[] };
+    // Newegg open-box scrape
+    const neweggBatch = await fetchNeweggClearance(useNewegg).catch((err) => {
+      console.warn('[scheduler] newegg fetch failed', err);
+      return { storeId: 'newegg-online', items: [] as any[] };
+    });
+    ingestItems.push(
+      ...mapLegacyItems(neweggBatch.items, {
+        source: neweggBatch.storeId,
+        channel: 'online',
+        confidence: useNewegg ? 'scrape' : 'heuristic',
       })
     );
+    sources.push({ storeId: neweggBatch.storeId, count: neweggBatch.items.length });
 
     const enrichment = await refreshBestBuyForHotWatches(env);
 
-    const batches = await Promise.all(adapterPromises);
-
-    const items = batches.flatMap((b) => b.items);
-    const sources = batches.map((b) => ({ storeId: (b as any)?.storeId || 'unknown', count: b.items?.length ?? 0 }));
-    console.log('[scheduler] flags:', { useRealBBY, useRealMC, useRealNE, allowDevStubs });
-    console.log('[scheduler] adapter batches:', sources.map((s) => `${s.storeId}:${s.count}`).join(', '));
-    if (items.length === 0) return { ok: true, ingested: 0, flags: { useRealBBY, useRealMC, useRealNE, allowDevStubs }, sources } as any;
-
-    const ingestUrl: string = env.INGEST_URL || '';
-    if (!ingestUrl) return { ok: false, error: 'INGEST_URL not set', ingested: 0 };
+    if (!ingestItems.length) {
+      return {
+        ok: true,
+        ingested: 0,
+        flags: {
+          enableMicroCenterStore,
+          enableBestBuyStore,
+          useBestBuyApi,
+          useMicroCenterDom,
+          useNewegg,
+          allowDevStubs,
+        },
+        sources,
+        enrichment,
+      } as any;
+    }
 
     try {
-      const r = await fetch(ingestUrl, {
-        method: 'POST',
-        headers: {
-          'content-type': 'application/json',
-          'authorization': `Bearer ${env.CRON_SHARED_SECRET}`,
-        },
-        body: JSON.stringify({ items }),
+      const ingestResult = await postIngest(ingestItems, {
+        ingestUrl: env.INGEST_URL,
+        secret: env.CRON_SHARED_SECRET,
       });
-
-      const json = await r.json().catch(() => ({}));
-      return { ok: r.ok, status: r.status, ingested: json.inserted ?? 0, flags: { useRealBBY, useRealMC, useRealNE, allowDevStubs }, sources, enrichment } as any;
-    } catch (e: any) {
-      return { ok: false, error: e?.message || String(e), step: 'ingest', ingestUrl, flags: { useRealBBY, useRealMC, useRealNE, allowDevStubs }, sources, enrichment } as any;
+      return {
+        ok: true,
+        ingested: ingestResult.inserted,
+        status: ingestResult.status,
+        flags: {
+          enableMicroCenterStore,
+          enableBestBuyStore,
+          useBestBuyApi,
+          useMicroCenterDom,
+          useNewegg,
+          allowDevStubs,
+        },
+        sources,
+        enrichment,
+      } as any;
+    } catch (err: any) {
+      return {
+        ok: false,
+        error: err?.message || String(err),
+        step: 'ingest',
+        flags: {
+          enableMicroCenterStore,
+          enableBestBuyStore,
+          useBestBuyApi,
+          useMicroCenterDom,
+          useNewegg,
+          allowDevStubs,
+        },
+        sources,
+        enrichment,
+      } as any;
     }
-  }
-}
+  },
+};

--- a/worker/src/sources/bestbuy/storeScraper.ts
+++ b/worker/src/sources/bestbuy/storeScraper.ts
@@ -1,0 +1,165 @@
+import { withRateLimit } from '../../util/rate';
+import type { IngestPayload } from '../../ingest';
+import type { StoreConfig } from '../types';
+import type { StoreScrapeResult } from '../result';
+
+type Browser = {
+  newContext(options?: any): Promise<BrowserContext>;
+  close(): Promise<void>;
+};
+
+type BrowserContext = {
+  newPage(): Promise<Page>;
+  close(): Promise<void>;
+};
+
+type Page = {
+  goto(url: string, options?: Record<string, any>): Promise<void>;
+  $$(selector: string): Promise<any[]>;
+  close(): Promise<void>;
+};
+
+async function loadChromium() {
+  try {
+    const mod: any = await import('playwright-core');
+    if (mod?.chromium?.launch) return mod.chromium;
+  } catch (err) {
+    console.warn('[bestbuy] playwright-core not available', err);
+  }
+  throw new Error(
+    'playwright-core is required to scrape Best Buy store pages. Install it in the worker package before enabling this source.'
+  );
+}
+
+function toStoreMeta(store: StoreConfig) {
+  return {
+    retailer: 'bestbuy' as const,
+    source: 'bestbuy-store',
+    channel: 'store',
+    confidence: 'scrape',
+    storeId: store.id,
+    storeName: store.name,
+    storeCity: store.city,
+    storeState: store.state,
+  };
+}
+
+function parsePriceToCents(text: string): number | null {
+  const cleaned = text.replace(/[,\s]/g, '');
+  const match = cleaned.match(/\$?(\d+(?:\.\d{1,2})?)/);
+  if (!match) return null;
+  return Math.round(parseFloat(match[1]) * 100);
+}
+
+async function ensureBrowser(headless: boolean): Promise<Browser> {
+  const chromium = await loadChromium();
+  return chromium.launch({ headless });
+}
+
+async function textFrom(card: any, selectors: string[]): Promise<string> {
+  for (const sel of selectors) {
+    try {
+      const handle = await card.$(sel);
+      if (!handle) continue;
+      const text = (await handle.textContent())?.replace(/\s+/g, ' ').trim();
+      await handle.dispose();
+      if (text) return text;
+    } catch {}
+  }
+  return '';
+}
+
+async function attrFrom(card: any, selectors: string[], attr: string): Promise<string> {
+  for (const sel of selectors) {
+    try {
+      const handle = await card.$(sel);
+      if (!handle) continue;
+      const value = await handle.getAttribute(attr);
+      await handle.dispose();
+      if (value && value.trim()) return value.trim();
+    } catch {}
+  }
+  return '';
+}
+
+function resolveUrl(href: string, base: string): string | null {
+  if (!href) return null;
+  try {
+    return new URL(href, base).toString();
+  } catch {
+    return null;
+  }
+}
+
+export type BestBuyScrapeOptions = {
+  headless?: boolean;
+  rateLimitMs?: number;
+};
+
+export async function scrapeBestBuyStores(
+  stores: StoreConfig[],
+  options: BestBuyScrapeOptions = {}
+): Promise<StoreScrapeResult> {
+  if (!stores.length) {
+    return { items: [], metrics: [] };
+  }
+
+  const headless = options.headless !== false;
+  const rateLimit = options.rateLimitMs ?? 900;
+  const browser = await ensureBrowser(headless);
+  const context = await browser.newContext();
+  const page = await context.newPage();
+
+  const items: IngestPayload[] = [];
+  const metrics: StoreScrapeResult['metrics'] = [];
+  const seen = new Set<string>();
+
+  try {
+    for (const store of stores) {
+      const before = items.length;
+      const meta = toStoreMeta(store);
+      await withRateLimit(async () => {
+        await page.goto(store.url, { waitUntil: 'domcontentloaded', timeout: 45_000 });
+        const cards = await page.$$('.sku-item, article.sku-item, li.sku-item, article');
+        for (const card of cards) {
+          const skuAttr = await attrFrom(card, ['[data-sku-id]'], 'data-sku-id');
+          const title = await textFrom(card, ['.sku-header a', '.sku-title a', '.sku-title', 'h4 a', 'h4']);
+          if (!title) continue;
+          const priceText = await textFrom(card, ['.priceView-customer-price', '.priceView-hero-price span', '.price']);
+          const priceCents = parsePriceToCents(priceText || '');
+          if (!priceCents) continue;
+
+          const href = await attrFrom(card, ['.sku-header a', '.sku-title a', 'a[href]'], 'href');
+          const resolvedUrl = resolveUrl(href, store.url) || store.url;
+          const image =
+            (await attrFrom(card, ['img'], 'data-src')) ||
+            (await attrFrom(card, ['img'], 'data-original')) ||
+            (await attrFrom(card, ['img'], 'src'));
+
+          const key = skuAttr ? `${meta.storeId}:${skuAttr}` : `${meta.storeId}:${resolvedUrl}`;
+          if (seen.has(key)) continue;
+          seen.add(key);
+
+          items.push({
+            ...meta,
+            sku: skuAttr || undefined,
+            title,
+            priceCents,
+            conditionLabel: 'Open-Box',
+            url: resolvedUrl,
+            seenAt: new Date().toISOString(),
+            imageUrl: image,
+          });
+        }
+      }, rateLimit);
+
+      metrics.push({ storeId: store.id, count: items.length - before, url: store.url });
+    }
+  } finally {
+    await page.close();
+    await context.close();
+    await browser.close();
+  }
+
+  return { items, metrics };
+}

--- a/worker/src/sources/microcenter/storeScraper.ts
+++ b/worker/src/sources/microcenter/storeScraper.ts
@@ -1,0 +1,189 @@
+import { withRateLimit } from '../../util/rate';
+import type { IngestPayload } from '../../ingest';
+import type { StoreConfig } from '../types';
+import type { StoreScrapeResult } from '../result';
+
+type Browser = {
+  newContext(options?: any): Promise<BrowserContext>;
+  close(): Promise<void>;
+};
+
+type BrowserContext = {
+  newPage(): Promise<Page>;
+  close(): Promise<void>;
+};
+
+type Page = {
+  goto(url: string, options?: Record<string, any>): Promise<void>;
+  $$(selector: string): Promise<any[]>;
+  close(): Promise<void>;
+};
+
+async function loadChromium() {
+  try {
+    const mod: any = await import('playwright-core');
+    if (mod?.chromium?.launch) return mod.chromium;
+  } catch (err) {
+    console.warn('[microcenter] playwright-core not available', err);
+  }
+  throw new Error(
+    'playwright-core is required to scrape Micro Center store pages. Install it in the worker package before enabling this source.'
+  );
+}
+
+function toStoreMeta(store: StoreConfig) {
+  return {
+    retailer: 'microcenter' as const,
+    source: 'microcenter-store',
+    channel: 'store',
+    confidence: 'scrape',
+    storeId: store.id,
+    storeName: store.name,
+    storeCity: store.city,
+    storeState: store.state,
+  };
+}
+
+function parsePriceToCents(text: string): number | null {
+  const cleaned = text.replace(/[,\s]/g, '');
+  const match = cleaned.match(/\$?(\d+(?:\.\d{1,2})?)/);
+  if (!match) return null;
+  return Math.round(parseFloat(match[1]) * 100);
+}
+
+function inferCondition(input: string): string {
+  const normalized = input.toLowerCase();
+  if (normalized.includes('refurb')) return 'Refurbished';
+  if (normalized.includes('clearance')) return 'Clearance';
+  if (normalized.includes('demo')) return 'Demo';
+  return 'Open-Box';
+}
+
+async function extractText(el: any, selectors: string[]): Promise<string> {
+  for (const sel of selectors) {
+    try {
+      const handle = await el.$(sel);
+      if (!handle) continue;
+      const text = (await handle.textContent())?.replace(/\s+/g, ' ').trim();
+      await handle.dispose();
+      if (text) return text;
+    } catch {}
+  }
+  return '';
+}
+
+async function extractAttribute(el: any, selectors: string[], attr: string): Promise<string> {
+  for (const sel of selectors) {
+    try {
+      const handle = await el.$(sel);
+      if (!handle) continue;
+      const value = await handle.getAttribute(attr);
+      await handle.dispose();
+      if (value && value.trim()) return value.trim();
+    } catch {}
+  }
+  return '';
+}
+
+function resolveUrl(href: string, base: string): string | null {
+  if (!href) return null;
+  try {
+    return new URL(href, base).toString();
+  } catch {
+    return null;
+  }
+}
+
+function normalizeImage(src: string | null | undefined, base: string): string | undefined {
+  if (!src) return undefined;
+  const trimmed = src.trim();
+  if (!trimmed) return undefined;
+  if (trimmed.startsWith('//')) return `https:${trimmed}`;
+  if (/^https?:/i.test(trimmed)) return trimmed;
+  try {
+    return new URL(trimmed, base).toString();
+  } catch {
+    return undefined;
+  }
+}
+
+async function ensureBrowser(headless: boolean): Promise<Browser> {
+  const chromium = await loadChromium();
+  return chromium.launch({ headless });
+}
+
+export type MicroCenterScrapeOptions = {
+  headless?: boolean;
+  rateLimitMs?: number;
+};
+
+export async function scrapeMicroCenterStores(
+  stores: StoreConfig[],
+  options: MicroCenterScrapeOptions = {}
+): Promise<StoreScrapeResult> {
+  if (!stores.length) {
+    return { items: [], metrics: [] };
+  }
+
+  const headless = options.headless !== false;
+  const rateLimit = options.rateLimitMs ?? 1000;
+  const browser = await ensureBrowser(headless);
+  const context = await browser.newContext();
+  const page = await context.newPage();
+
+  const items: IngestPayload[] = [];
+  const metrics: StoreScrapeResult['metrics'] = [];
+  const seen = new Set<string>();
+
+  try {
+    for (const store of stores) {
+      const before = items.length;
+      const meta = toStoreMeta(store);
+      await withRateLimit(async () => {
+        await page.goto(store.url, { waitUntil: 'domcontentloaded', timeout: 45_000 });
+        const cards = await page.$$('.product_wrapper, .product, .product_tile, .productGrid .product, li.product, article');
+        for (const card of cards) {
+          const title = await extractText(card, ['.product_title', '.details .name', '.product_name', '.productTitle', 'a']);
+          if (!title) continue;
+          const priceText = await extractText(card, ['.price', '.price .value', '[class*="price"]', '.price-wrapper']);
+          const priceCents = parsePriceToCents(priceText);
+          if (!priceCents) continue;
+
+          const href = await extractAttribute(card, ['a[href*="/product/"]', 'a[href]'], 'href');
+          const resolvedUrl = resolveUrl(href, store.url) || store.url;
+          const imageSrcset = await extractAttribute(card, ['img'], 'srcset');
+          const imageCandidate =
+            (await extractAttribute(card, ['img'], 'data-src')) ||
+            (await extractAttribute(card, ['img'], 'data-original')) ||
+            (imageSrcset ? imageSrcset.split(' ')[0] : '') ||
+            (await extractAttribute(card, ['img'], 'src'));
+
+          const key = `${meta.storeId}:${resolvedUrl}`;
+          if (seen.has(key)) continue;
+          seen.add(key);
+
+          const conditionText =
+            (await extractText(card, ['.product_condition', '.condition', '.productCondition', '.product_promo'])) || title;
+
+          items.push({
+            ...meta,
+            title,
+            priceCents,
+            conditionLabel: inferCondition(conditionText),
+            url: resolvedUrl,
+            seenAt: new Date().toISOString(),
+            imageUrl: normalizeImage(imageCandidate, resolvedUrl),
+          });
+        }
+      }, rateLimit);
+
+      metrics.push({ storeId: store.id, count: items.length - before, url: store.url });
+    }
+  } finally {
+    await page.close();
+    await context.close();
+    await browser.close();
+  }
+
+  return { items, metrics };
+}

--- a/worker/src/sources/result.ts
+++ b/worker/src/sources/result.ts
@@ -1,0 +1,7 @@
+import type { ScrapeMetrics } from './types';
+import type { IngestPayload } from '../ingest';
+
+export type StoreScrapeResult = {
+  items: IngestPayload[];
+  metrics: ScrapeMetrics[];
+};

--- a/worker/src/sources/types.ts
+++ b/worker/src/sources/types.ts
@@ -1,0 +1,13 @@
+export type StoreConfig = {
+  id: string;
+  name: string;
+  city?: string;
+  state?: string;
+  url: string;
+};
+
+export type ScrapeMetrics = {
+  storeId: string;
+  count: number;
+  url: string;
+};

--- a/worker/src/util/rate.ts
+++ b/worker/src/util/rate.ts
@@ -1,0 +1,7 @@
+export async function withRateLimit<T>(fn: () => Promise<T>, ms = 800): Promise<T> {
+  const result = await fn();
+  if (ms > 0) {
+    await new Promise((resolve) => setTimeout(resolve, ms));
+  }
+  return result;
+}

--- a/worker/wrangler.toml
+++ b/worker/wrangler.toml
@@ -14,8 +14,14 @@ enabled = true
 # Point to your local Next dev server ingest endpoint
 # If your Next runs on :3001, change to http://localhost:3001/api/ingest
 INGEST_URL = "https://openboxradar.com/api/ingest"
-USE_REAL_MICROCENTER = "1"
+ENABLE_MC_STORE_SCRAPE = "1"
+ENABLE_BB_STORE_SCRAPE = "1"
+PLAYWRIGHT_HEADLESS = "1"
+MICROCENTER_RATE_LIMIT_MS = "1000"
+BESTBUY_RATE_LIMIT_MS = "900"
 MICROCENTER_STORE_IDS = "mc-cambridge"
+BESTBUY_STORE_IDS = "bby-123"
+USE_REAL_MICROCENTER = "1"
 USE_REAL_BESTBUY = "1"
 USE_REAL_NEWEGG = "0"
 ALLOW_DEV_STUBS = "0"


### PR DESCRIPTION
## Summary
- add Playwright-powered store scrapers for Micro Center and Best Buy with shared rate limiting and ingestion helpers, plus scheduler wiring and feature flags
- record channel and confidence metadata during ingest and surface a debug API for source counts
- document new worker flags and Playwright setup notes for running the scrapers

## Testing
- ⚠️ `pnpm lint` *(fails: Next.js prompted for ESLint setup and the command was aborted)*

------
https://chatgpt.com/codex/tasks/task_e_68cf1e529ad4832bb61870fca49eeeb2