### PR TITLE
Remove Playwright dependency from Best Buy store scraper

### DIFF
--- a/worker/src/scheduler.ts
+++ b/worker/src/scheduler.ts
@@ -197,7 +197,6 @@ export const Scheduler = {
     if (enableBestBuyStore) {
       const stores = parseStoreConfigs(env.BESTBUY_STORE_IDS, ['bby-123'], buildBestBuyStore);
       const bbResult = await scrapeBestBuyStores(stores, {
-        headless,
         rateLimitMs: Number(env.BESTBUY_RATE_LIMIT_MS || '900'),
       }).catch((err) => {
         console.warn('[scheduler] bestbuy store scrape failed', err);


### PR DESCRIPTION
## Summary
- replace the Best Buy store scraper's Playwright usage with a lightweight HTML fetch and parsing flow
- update the scheduler to stop passing headless-only options to the Best Buy scraper now that Playwright is no longer required

## Testing
- not run (no automated tests provided)


------
https://chatgpt.com/codex/tasks/task_e_68cf2b85c50c832baa10d5db9fe21427