### PR TITLE
Add Newegg retailer enum value

### DIFF
--- a/web/lib/drizzle/migrations/0029_add_newegg_retailer.sql
+++ b/web/lib/drizzle/migrations/0029_add_newegg_retailer.sql
@@ -1,0 +1,1 @@
+ALTER TYPE retailer_t ADD VALUE IF NOT EXISTS 'newegg';


### PR DESCRIPTION
## Summary
- add a migration that registers the `newegg` value with the `retailer_t` enum

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cff9a8c0e0832b8de3c7f009f61323