### PR TITLE
Remove redundant revalidate flag on no-store fetches

### DIFF
--- a/web/app/(marketing)/page.tsx
+++ b/web/app/(marketing)/page.tsx
@@ -8,7 +8,7 @@ type Item = { id: number; title: string; price_cents: number; url: string };
 function dollars(n: number) { return `$${(n/100).toFixed(2)}`; }
 
 async function fetchDrops(): Promise<Item[]> {
-  const res = await fetch(absoluteUrl('/api/inventory/trending?type=drops&limit=8'), { cache: 'no-store', next: { revalidate: 0 } });
+  const res = await fetch(absoluteUrl('/api/inventory/trending?type=drops&limit=8'), { cache: 'no-store' });
   const json = await res.json();
   return (json.items || []) as Item[];
 }

--- a/web/app/search/page.tsx
+++ b/web/app/search/page.tsx
@@ -80,8 +80,6 @@ export default async function SearchPage({ searchParams }: { searchParams: Recor
   try {
     const res = await fetch(absoluteUrl('/api/inventory/search') + '?' + qp.toString(), {
       cache: "no-store",
-      // Ensure server fetch regardless of deployment
-      next: { revalidate: 0 },
     });
 
     const contentType = res.headers.get("content-type") ?? "";


### PR DESCRIPTION
## Summary
- remove the redundant `next.revalidate` option from fetch calls that already disable caching with `cache: 'no-store'`

## Testing
- npm run lint *(fails: prompts for configuration setup)*

------
https://chatgpt.com/codex/tasks/task_e_68cffc064c98832b8d6484d1d01b181c