### PR TITLE
Add playwright-core dependency to worker

### DIFF
--- a/worker/package.json
+++ b/worker/package.json
@@ -7,7 +7,8 @@
     "deploy": "wrangler deploy"
   },
   "dependencies": {
-    "linkedom": "^0.15.6"
+    "linkedom": "^0.15.6",
+    "playwright-core": "^1.45.0"
   },
   "devDependencies": {
     "typescript": "5.5.4",

--- a/worker/pnpm-lock.yaml
+++ b/worker/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       linkedom:
         specifier: ^0.15.6
         version: 0.15.6
+      playwright-core:
+        specifier: ^1.45.0
+        version: 1.45.0
     devDependencies:
       typescript:
         specifier: 5.5.4


### PR DESCRIPTION
## Summary
- add the playwright-core package to the worker's dependencies so Micro Center scraping can launch Chromium
- lock the dependency version in the worker pnpm lockfile

## Testing
- not run (package installation requires external registry access)

------
https://chatgpt.com/codex/tasks/task_e_68d00ee13fd4832bb4550723d8580dda