### PR TITLE
Document scraper deployment configuration

### DIFF
--- a/worker/wrangler.toml
+++ b/worker/wrangler.toml
@@ -14,6 +14,9 @@ enabled = true
 # Point to your local Next dev server ingest endpoint
 # If your Next runs on :3001, change to http://localhost:3001/api/ingest
 INGEST_URL = "https://openboxradar.com/api/ingest"
+# Base URL for the Playwright scraper container (update per deploy)
+SCRAPER_URL = "http://127.0.0.1:3000"
+# Use `wrangler secret put SCRAPER_SECRET` to share the header with the scraper service
 ENABLE_MC_STORE_SCRAPE = "1"
 ENABLE_BB_STORE_SCRAPE = "1"
 PLAYWRIGHT_HEADLESS = "1"


### PR DESCRIPTION
## Summary
- describe the dedicated Playwright scraper service in the repo layout
- document how to deploy the container image, share SCRAPER_SECRET, and update worker env vars
- add SCRAPER_URL guidance to the worker wrangler config so the worker targets the deployed scraper

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d061adc37c832b819eeeacfaae4591